### PR TITLE
Changes to current time for insertion as trigger will be 5 minutes delayed, and changes to database schema

### DIFF
--- a/etl_pipeline/database/schema.sql
+++ b/etl_pipeline/database/schema.sql
@@ -67,24 +67,24 @@ CREATE TABLE customer_postcode_link(
 CREATE TABLE power_reading(
     power_reading_id INT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     date_time TIMESTAMP,    
-    gas float NOT NULL,
-    coal float NOT NULL,
     biomass float NOT NULL,
-    nuclear float NOT NULL,
-    hydro float NOT NULL,
+    coal float NOT NULL,
     imports float NOT NULL,
+    gas float NOT NULL,
+    nuclear float NOT NULL,
     other float NOT NULL,
-    wind float NOT NULL,
+    hydro float NOT NULL,
     solar float NOT NULL,
+    wind float NOT NULL,
     price float NOT NULL,
-    demand int NOT NULL,
-    belgium int NOT NULL,
-    france int NOT NULL,
-    netherlands int NOT NULL,
-    denmark int NOT NULL,
-    norway int NOT NULL,
-    ireland int NOT NULL,
-    n_ireland int NOT NULL
+    demand float NOT NULL,
+    belgium float NOT NULL,
+    denmark float NOT NULL,
+    france float NOT NULL,
+    ireland float NOT NULL,
+    netherlands float NOT NULL,
+    n_ireland float NOT NULL,
+    norway float NOT NULL
     );
 
 

--- a/etl_pipeline/power_readings/transform.py
+++ b/etl_pipeline/power_readings/transform.py
@@ -11,6 +11,9 @@ def calculate_avg_for_last_settlement(df: pd.DataFrame, column: str) -> float:
 
     df['startTime'] = pd.to_datetime(df['startTime'], utc=True)
 
+    # Reading come in 5 minutes interval, we are triggering readings at 35 past
+    # We want all 6 readings in the 30 minute window, therefore 39 is chosen
+    # 5 minutes are deducted due to tbe 35 and 5 past trigger
     end = datetime.now(timezone.utc) - timedelta(minutes=5)
     start = end - timedelta(minutes=39)
 
@@ -55,6 +58,7 @@ def summarize_energy_generation(df: pd.DataFrame, mappings: dict) -> dict:
 
 def combine_company_generation(df: pd.DataFrame) -> pd.DataFrame:
     """Combine different parts of a country to 1 country"""
+    # map to group all relevant countries in to one
     country_map = {
         'Belgium (ElecLink)': 'Belgium',
         'Belgium (Nemo Link)': 'Belgium',
@@ -78,8 +82,10 @@ def combine_company_generation(df: pd.DataFrame) -> pd.DataFrame:
 def transform_all_data(time: list) -> list:
     """Put all values in to a list ready to be inserted to database"""
 
+    # We are taking reading every 30 minutes, but triggering at 35 past
     all_data = []
-    all_data.append(time[0])
+    current_time = datetime.now() - timedelta(minutes=5)
+    all_data.append(current_time.isoformat())
 
     # National energy generation
     national_generation = get_national_energy_generation(time[0], time[1])

--- a/etl_pipeline/power_readings/transform.py
+++ b/etl_pipeline/power_readings/transform.py
@@ -11,9 +11,9 @@ def calculate_avg_for_last_settlement(df: pd.DataFrame, column: str) -> float:
 
     df['startTime'] = pd.to_datetime(df['startTime'], utc=True)
 
-    # Reading come in 5 minutes interval, we are triggering readings at 35 past
-    # We want all 6 readings in the 30 minute window, therefore 39 is chosen
-    # 5 minutes are deducted due to tbe 35 and 5 past trigger
+    # Readings come in 5-minute intervals; we are triggering readings at 5 and 35 past the hour.
+    # We want all 6 readings within the 30-minute window, so 39 minutes is chosen.
+    # 5 minutes are deducted due to the 5 and 35 past triggers.
     end = datetime.now(timezone.utc) - timedelta(minutes=5)
     start = end - timedelta(minutes=39)
 

--- a/etl_pipeline/power_readings/transform.py
+++ b/etl_pipeline/power_readings/transform.py
@@ -6,6 +6,34 @@ import pandas as pd
 from extract import get_utc_settlement_time, get_demand_summary, get_energy_pricing, get_generation_by_type, get_national_energy_generation
 
 
+INTERCONNECTOR_MAP = {
+    "INTELEC": "Belgium (ElecLink)",
+    "INTEW": "Ireland (East-West)",
+    "INTFR": "France (IFA)",
+    "INTIFA2": "France (IFA2)",
+    "INTIRL": "Northern Ireland (Moyle)",
+    "INTNED": "Netherlands (BritNed)",
+    "INTNEM": "Belgium (Nemo Link)",
+    "INTNSL": "Norway (North Sea Link)",
+    "INTVKL": "Denmark (Viking Link)",
+    "INTGRNL": "Ireland (Greenlink)"
+
+}
+
+COUNTRY_MAP = {
+    'Belgium (ElecLink)': 'Belgium',
+    'Belgium (Nemo Link)': 'Belgium',
+    'France (IFA)': 'France',
+    'France (IFA2)': 'France',
+    'Ireland (East-West)': 'Ireland',
+    'Ireland (Greenlink)': 'Ireland',
+    'Denmark (Viking Link)': 'Denmark',
+    'Netherlands (BritNed)': 'Netherlands',
+    'Northern Ireland (Moyle)': 'Northern Ireland',
+    'Norway (North Sea Link)': 'Norway',
+}
+
+
 def calculate_avg_for_last_settlement(df: pd.DataFrame, column: str) -> float:
     """Calculate average of a numeric column of a dataframe for the last settlement."""
 
@@ -20,23 +48,6 @@ def calculate_avg_for_last_settlement(df: pd.DataFrame, column: str) -> float:
     settlement = df[df['startTime'].between(start, end)]
     avg = settlement[column].mean()
     return avg
-
-
-def country_mappings() -> dict:
-    """Map acronym to correct country for energy generation"""
-    interconnector_map = {
-        "INTELEC": "Belgium (ElecLink)",
-        "INTEW": "Ireland (East-West)",
-        "INTFR": "France (IFA)",
-        "INTIFA2": "France (IFA2)",
-        "INTIRL": "Northern Ireland (Moyle)",
-        "INTNED": "Netherlands (BritNed)",
-        "INTNEM": "Belgium (Nemo Link)",
-        "INTNSL": "Norway (North Sea Link)",
-        "INTVKL": "Denmark (Viking Link)",
-        "INTGRNL": "Ireland (Greenlink)"
-    }
-    return interconnector_map
 
 
 def summarize_energy_generation(df: pd.DataFrame, mappings: dict) -> dict:
@@ -59,22 +70,12 @@ def summarize_energy_generation(df: pd.DataFrame, mappings: dict) -> dict:
 def combine_company_generation(df: pd.DataFrame) -> pd.DataFrame:
     """Combine different parts of a country to 1 country"""
     # map to group all relevant countries in to one
-    country_map = {
-        'Belgium (ElecLink)': 'Belgium',
-        'Belgium (Nemo Link)': 'Belgium',
-        'France (IFA)': 'France',
-        'France (IFA2)': 'France',
-        'Ireland (East-West)': 'Ireland',
-        'Ireland (Greenlink)': 'Ireland',
-        'Denmark (Viking Link)': 'Denmark',
-        'Netherlands (BritNed)': 'Netherlands',
-        'Northern Ireland (Moyle)': 'Northern Ireland',
-        'Norway (North Sea Link)': 'Norway',
-    }
 
-    df['country'] = df['country'].map(country_map)
+    df['country'] = df['country'].map(COUNTRY_MAP)
 
     result = df.groupby('country', as_index=False)['generation'].sum()
+
+    result['generation'] = result['generation'].round(2)
 
     return result
 
@@ -104,8 +105,7 @@ def transform_all_data(time: list) -> list:
     # Energy generation by country
     imports = get_generation_by_type(time[0].replace(
         '+00:00', 'Z'), time[1].replace('+00:00', 'Z'))
-    mapped_countries = country_mappings()
-    summary = summarize_energy_generation(imports, mapped_countries)
+    summary = summarize_energy_generation(imports, INTERCONNECTOR_MAP)
     combined_countries = combine_company_generation(summary)
     all_data.extend(combined_countries['generation'].tolist())
 


### PR DESCRIPTION
# Pull Request

## Description

I have made changes to the current timestamp when inserting to the power_readings table, as discussed we will have the trigger at 35 and 5 minutes past due to the API delay, therefore i have added current time - 5 minutes as our functions only pull data in 30 minute windows.
Changes to the power_readings table database schema to adapt to the order in which the data will be inserted, also changed the data types of some values as they are expected to be float not only integers.

I have tested the adapted schema by creating the tables again locally and it was successful.

Closes #94 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
