### PR TITLE
Making the rds publicly accessible

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -44,6 +44,7 @@ resource "aws_db_instance" "c19-energy-monitor-rds" {
   skip_final_snapshot  = true
   vpc_security_group_ids = [aws_security_group.c19-rds-sg.id]
   db_subnet_group_name = aws_db_subnet_group.c19-subnet-groups.name
+  publicly_accessible = true
 }
 
 


### PR DESCRIPTION
# Pull Request

## Description

Sets the publicly accessible option to true when creating the RDS to allow for it to be accessed from local machines during development

Fixes #96 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes