### PR TITLE
Fixed datetime reading to be on the hour and half/hour and removed unnecessary imports

### DIFF
--- a/etl_pipeline/power_readings/transform_carbon.py
+++ b/etl_pipeline/power_readings/transform_carbon.py
@@ -1,7 +1,6 @@
 """Script with the functions to transform the carbon intensity data from the NESO API."""
 
-from extract_carbon import extract_carbon_intensity_data, get_utc_settlement_time
-from datetime import datetime
+from datetime import datetime, timedelta
 
 
 def transform_generation_mix(region: dict) -> list[float]:
@@ -22,7 +21,11 @@ def transform_carbon_intensity_data(carbon_data: list[dict]) -> list[list]:
     transformed_data = []
 
     for region in carbon_data:
-        time = datetime.now()
+        # We are taken readings every half hour, starting at 5 minutes past the hour
+        # to account for the price reading. However, the readings we are taking are for
+        # the half-hour settlement period from half-past to the hour, therefore we want
+        # the reading time to reflect this by being on the hour, hence, we subtract 5 minutes.
+        time = datetime.now() - timedelta(minutes=5)
         region_id = region["regionid"]
         intensity = region["intensity"]["forecast"]
         l = [time, intensity, region_id]

--- a/etl_pipeline/power_readings/transform_carbon.py
+++ b/etl_pipeline/power_readings/transform_carbon.py
@@ -21,10 +21,10 @@ def transform_carbon_intensity_data(carbon_data: list[dict]) -> list[list]:
     transformed_data = []
 
     for region in carbon_data:
-        # We are taken readings every half hour, starting at 5 minutes past the hour
+        # We are taking readings every half-hour, starting at 5 minutes past the hour
         # to account for the price reading. However, the readings we are taking are for
         # the half-hour settlement period from half-past to the hour, therefore we want
-        # the reading time to reflect this by being on the hour, hence, we subtract 5 minutes.
+        # the reading time to reflect this by being on the hour/half-hour, hence, we subtract 5 minutes.
         time = datetime.now() - timedelta(minutes=5)
         region_id = region["regionid"]
         intensity = region["intensity"]["forecast"]


### PR DESCRIPTION
# Pull Request

## Description

Changed the entry for the datetime column in the carbon_reading table to be 5 minutes earlier. Reasoning:

We are taking readings every half hour, starting at 5 minutes past the hour to account for the price reading. However, the readings we are taking are for the half-hour settlement period from half-past to the hour, therefore we want the reading time to reflect this by being on the hour, hence, we subtract 5 minutes.

Closes #99 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
