### PR TITLE
Remove carbon reading from actions

### DIFF
--- a/.github/workflows/pylint-pytest.yml
+++ b/.github/workflows/pylint-pytest.yml
@@ -27,11 +27,6 @@ jobs:
         run: |
           cd dashboard
           pip install -r requirements.txt     
-      
-      - name: Install carbon reading requirements
-        run: |
-          cd etl_pipeline/carbon_readings
-          pip install -r requirements.txt  
 
       - name: Install outages requirements
         run: |
@@ -63,11 +58,6 @@ jobs:
         run: |
           cd dashboard
           pip install -r requirements.txt     
-
-      - name: Install carbon reading requirements
-        run: |
-          cd etl_pipeline/carbon_readings
-          pip install -r requirements.txt 
 
       - name: Install outages requirements
         run: |


### PR DESCRIPTION
# Pull Request

## Description

Removing any mention of `carbon_readings` directory in github actions, as I removed it when pulling together the ETL for the carbon and power readings. This means my pull request does not run as the directory does not exist and so the request cannot be merged. 

Closes #125 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
