### PR TITLE
Added dockerfile for carbon/power reading ETL

### DIFF
--- a/etl_pipeline/power_readings/dockerfile
+++ b/etl_pipeline/power_readings/dockerfile
@@ -1,0 +1,17 @@
+FROM public.ecr.aws/lambda/python:latest
+
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+COPY requirements.txt .
+
+RUN pip install -r requirements.txt
+
+COPY extract_carbon.py .
+COPY extract_power.py .
+COPY transform_carbon.py .
+COPY transform_power.py .
+COPY load_carbon.py .
+COPY load_power.py .
+COPY load_main.py .
+
+CMD [ "load_main.handler" ]

--- a/etl_pipeline/power_readings/dockerfile
+++ b/etl_pipeline/power_readings/dockerfile
@@ -1,3 +1,4 @@
+# Set the AWS base image for a lambda function 
 FROM public.ecr.aws/lambda/python:latest
 
 WORKDIR ${LAMBDA_TASK_ROOT}
@@ -6,6 +7,7 @@ COPY requirements.txt .
 
 RUN pip install -r requirements.txt
 
+# Load all necessary files for the ETL pipelines
 COPY extract_carbon.py .
 COPY extract_power.py .
 COPY transform_carbon.py .


### PR DESCRIPTION
# Pull Request

## Description

Added a dockerfile for the carbon/power reading ETL pipeline. The dockerfile should only contain the files required for both ETL pipelines to run and must include the correct code for running the process as an AWS Lambda function.

Closes #135 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
