### PR TITLE
Schedulers for ETL processes

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -268,7 +268,7 @@ resource "aws_iam_role_policy_attachment" "c19-energy-monitor-scheduler-role-att
 }
 
 # eventbridge scheduler for carbon/power reading ETL
-resource "aws_scheduler_schedule" "c19_energy_monitor_reading_ETL_etl_scheduler" {
+resource "aws_scheduler_schedule" "c19-energy-monitor-reading-etl-scheduler" {
   name        = "c19-energy-monitor-reading-ETL-scheduler"
   description = "Run reading ETL job every 30 minutes at 5 past the hour."
 
@@ -287,7 +287,7 @@ resource "aws_scheduler_schedule" "c19_energy_monitor_reading_ETL_etl_scheduler"
 
 
 # eventbridge scheduler for outage ETL
-resource "aws_scheduler_schedule" "c19_ajldka_short_term_etl_scheduler" {
+resource "aws_scheduler_schedule" "c19-energy-monitor-outage-step-scheduler" {
   name        = "c19-energy-monitor-reading-ETL-scheduler"
   description = "Run outage ETL job every 5."
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -254,7 +254,7 @@ resource "aws_iam_role" "c19-energy-monitor-scheduler-role" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          Service = "[scheduler.amazonaws.com](http://scheduler.amazonaws.com)"
+          Service = "scheduler.amazonaws.com"
         }
       }
     ]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,6 +74,33 @@ resource "aws_lambda_function" "c19-energy-outage-etl-lambda" {
 
 }
 
+
+
+
+resource "aws_lambda_function" "c19-energy-summary-email-lambda" {
+  function_name = "c19-energy-generation-etl-lambda"
+  role          = aws_iam_role.c19-etl-lambda-role.arn
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.c19-energy-monitor-readings.repository_url}:latest"
+
+  environment {
+    variables = {
+      ACCESS_KEY = var.ACCESS_KEY,
+      SECRET_ACCESS_KEY = var.ACCESS_KEY,
+      REGION = var.REGION,
+      DB_HOST = var.DB_HOST,
+      DB_PORT = var.DB_PORT,
+      DB_NAME = var.DB_NAME,
+      DB_USERNAME = var.DB_USERNAME,
+      DB_PASSWORD = var.DB_PASSWORD
+    }
+  }
+
+  memory_size = 512
+  timeout     = 30
+
+}
+
 resource "aws_db_instance" "c19-energy-monitor-rds" {
   allocated_storage    = 10
   identifier           = "c19-energy-monitor-rds"
@@ -217,15 +244,6 @@ resource "aws_ecr_repository" "c19-energy-monitor-outages" {
 
 resource "aws_ecr_repository" "c19-energy-monitor-summary" {
   name = "c19-energy-monitor-summary"
-  image_tag_mutability = "MUTABLE"
-
-  image_scanning_configuration {
-    scan_on_push = true
-  }
-}
-
-resource "aws_ecr_repository" "c19-energy-monitor-alert" {
-  name = "c19-energy-monitor-alert"
   image_tag_mutability = "MUTABLE"
 
   image_scanning_configuration {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,74 +4,75 @@ provider "aws" {
   secret_key = var.SECRET_KEY
 }
 
-# # IAM role for Lambda execution
+# IAM role for Lambda execution
 
-# data "aws_iam_policy_document" "assume_role" {
-#   statement {
-#     effect = "Allow"
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
 
-#     principals {
-#       type        = "Service"
-#       identifiers = ["lambda.amazonaws.com"]
-#     }
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
 
-#     actions = ["sts:AssumeRole"]
-#   }
-# }
+    actions = ["sts:AssumeRole"]
+  }
+}
 
-# resource "aws_iam_role" "c19-etl-lambda-role" {
-#   name               = "c19-energy-etl-lambda-role"
-#   assume_role_policy = data.aws_iam_policy_document.assume_role.json
-# }
+resource "aws_iam_role" "c19-etl-lambda-role" {
+  name               = "c19-energy-etl-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
 
-# # Lambda Function 
+# Lambda Function 
 
-# resource "aws_lambda_function" "c19-energy-generation-etl-lambda" {
-#   function_name = "c19-energy-generation-etl-lambda"
-#   role          = aws_iam_role.c19-etl-lambda-role.arn
-#   package_type  = "Image"
-#   image_uri     = "${aws_ecr_repository.example.repository_url}:latest"
+resource "aws_lambda_function" "c19-energy-generation-etl-lambda" {
+  function_name = "c19-energy-generation-etl-lambda"
+  role          = aws_iam_role.c19-etl-lambda-role.arn
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.c19-energy-monitor-readings.repository_url}:latest"
 
-#   environment {
-#     variables = {
-#       ACCESS_KEY = var.ACCESS_KEY,
-#       SECRET_ACCESS_KEY = var.ACCESS_KEY,
-#       REGION = var.REGION,
-#       DB_PORT = var.DB_PORT,
-#       DB_NAME = var.DB_NAME,
-#       DB_USERNAME = var.DB_USERNAME,
-#       DB_PASSWORD = var.DB_PASSWORD
-#     }
-#   }
+  environment {
+    variables = {
+      ACCESS_KEY = var.ACCESS_KEY,
+      SECRET_ACCESS_KEY = var.ACCESS_KEY,
+      REGION = var.REGION,
+      DB_HOST = var.DB_HOST,
+      DB_PORT = var.DB_PORT,
+      DB_NAME = var.DB_NAME,
+      DB_USERNAME = var.DB_USERNAME,
+      DB_PASSWORD = var.DB_PASSWORD
+    }
+  }
 
-#   memory_size = 512
-#   timeout     = 30
+  memory_size = 512
+  timeout     = 30
 
-#   architectures = ["arm64"] # Graviton support for better price/performance
-# }
+}
 
-# resource "aws_lambda_function" "c19-energy-outage-etl-lambda" {
-#   function_name = "c19-energy-outage-etl-lambda"
-#   role          = aws_iam_role.c19-etl-lambda-role.arn
-#   package_type  = "Image"
-#   image_uri     = "${aws_ecr_repository.example.repository_url}:latest"
+resource "aws_lambda_function" "c19-energy-outage-etl-lambda" {
+  function_name = "c19-energy-outage-etl-lambda"
+  role          = aws_iam_role.c19-etl-lambda-role.arn
+  package_type  = "Image"
+  image_uri     = "${aws_ecr_repository.c19-energy-monitor-outages.repository_url}:latest"
+  
+  environment {
+    variables = {
+      ACCESS_KEY = var.ACCESS_KEY,
+      SECRET_ACCESS_KEY = var.ACCESS_KEY,
+      REGION = var.REGION,
+      DB_HOST = var.DB_HOST,
+      DB_PORT = var.DB_PORT,
+      DB_NAME = var.DB_NAME,
+      DB_USERNAME = var.DB_USERNAME,
+      DB_PASSWORD = var.DB_PASSWORD
+    }
+  }
 
-#   environment {
-#     variables = {
-#       ACCESS_KEY = var.ACCESS_KEY,
-#       SECRET_ACCESS_KEY = var.ACCESS_KEY,
-#       REGION = var.REGION,
-#       DB_PORT = var.DB_PORT,
-#       DB_NAME = var.DB_NAME,
-#       DB_USERNAME = var.DB_USERNAME,
-#       DB_PASSWORD = var.DB_PASSWORD
-#     }
-#   }
+  memory_size = 512
+  timeout     = 30
 
-#   memory_size = 512
-#   timeout     = 30
-
-#   architectures = ["arm64"] 
+}
 
 resource "aws_db_instance" "c19-energy-monitor-rds" {
   allocated_storage    = 10
@@ -116,7 +117,7 @@ resource "aws_ecs_task_definition" "c19-energy-monitor-dashboard" {
   container_definitions = jsonencode([
     {
         name = "c19-energy-monitor-dashboard"
-        image = "uri:latest"
+        image = "${aws_ecr_repository.c19-energy-monitor-dashboard.repository_url}:latest"
         memory = 128
         essential = true,
         portMappings = [
@@ -139,6 +140,7 @@ resource "aws_ecs_task_definition" "c19-energy-monitor-dashboard" {
             {name = "DB_NAME", value = var.DB_NAME},
             {name = "DB_USERNAME", value = var.DB_USERNAME},
             {name = "DB_PASSWORD", value = var.DB_PASSWORD},
+            {name = "DB_HOST", value = var.DB_HOST},
             {name = "DB_PORT", value = var.DB_PORT},
             {name = "AWS_ACCESS_KEY", value = var.ACCESS_KEY},
             {name = "AWS_SECRET_KEY", value = var.SECRET_KEY},

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -254,7 +254,7 @@ resource "aws_iam_role" "c19-energy-monitor-scheduler-role" {
         Action = "sts:AssumeRole"
         Effect = "Allow"
         Principal = {
-          Service = "scheduler.amazonaws.com"
+          Service = ["scheduler.amazonaws.com"]
         }
       }
     ]
@@ -286,20 +286,40 @@ resource "aws_scheduler_schedule" "c19-energy-monitor-reading-etl-scheduler" {
 }
 
 
-# eventbridge scheduler for outage ETL
-resource "aws_scheduler_schedule" "c19-energy-monitor-outage-step-scheduler" {
-  name        = "c19-energy-monitor-reading-ETL-scheduler"
-  description = "Run outage ETL job every 5."
 
-  flexible_time_window {
-    mode = "OFF"
-  }
 
-  schedule_expression          = "cron(*/5 * * * ? *)"
-  schedule_expression_timezone = "Europe/London"
+# # eventbridge scheduler for outage ETL (will be step function assigned, not Lambda)
+# resource "aws_scheduler_schedule" "c19-energy-monitor-outage-step-scheduler" {
+#   name        = "c19-energy-monitor-reading-ETL-scheduler"
+#   description = "Run outage ETL job every 5."
 
-  target {
-    arn      = aws_lambda_function.c19-energy-outage-etl-lambda.arn
-    role_arn = aws_iam_role.c19-energy-monitor-scheduler-role.arn
-  }
-}
+#   flexible_time_window {
+#     mode = "OFF"
+#   }
+
+#   schedule_expression          = "cron(*/5 * * * ? *)"
+#   schedule_expression_timezone = "Europe/London"
+
+#   target {
+#     arn      = aws_lambda_function.c19-energy-outage-etl-lambda.arn
+#     role_arn = aws_iam_role.c19-energy-monitor-scheduler-role.arn
+#   }
+# }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -78,10 +78,10 @@ resource "aws_lambda_function" "c19-energy-outage-etl-lambda" {
 
 
 resource "aws_lambda_function" "c19-energy-summary-email-lambda" {
-  function_name = "c19-energy-generation-etl-lambda"
+  function_name = "c19-energy-summary-etl-lambda"
   role          = aws_iam_role.c19-etl-lambda-role.arn
   package_type  = "Image"
-  image_uri     = "${aws_ecr_repository.c19-energy-monitor-readings.repository_url}:latest"
+  image_uri     = "${aws_ecr_repository.c19-energy-monitor-summary.repository_url}:latest"
 
   environment {
     variables = {
@@ -343,21 +343,3 @@ resource "aws_scheduler_schedule" "c19-energy-monitor-outage-step-scheduler" {
     role_arn = aws_iam_role.c19-energy-monitor-scheduler-role.arn
   }
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,6 +26,10 @@ variable "VPC_PUBLIC_SUBNET_3" {
     type = string
 }
 
+variable "DB_HOST" {
+  type = string
+}
+
 variable "DB_NAME" {
   type = string
 }


### PR DESCRIPTION
# Pull Request

## Description

Code written for reading and outage ETL schedulers in Terraform. However, the scheduler execution role isn't able to invoke the Lambda function. It works when I switch to a role I made on using the UI which does have that permission which indicates that is the problem. I have followed the same structure I used last project but can't seem to spot the reason why if someone would like to take a look.  

Down the line, the outage scheduler will have to work on the step function, not the Lambda itself. 

Fixes #137 

## Type of change

- [x] New feature (non-breaking change which adds functionality)



## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings

