### PR TITLE
Fix changed wording of the outage email

### DIFF
--- a/etl_pipeline/outages/power_outages_emails.py
+++ b/etl_pipeline/outages/power_outages_emails.py
@@ -36,7 +36,7 @@ def email_body(outage_data: pd.DataFrame):
     </head>
     <body>
         <h1>⚠️ Power Outage Alert</h1>
-        <h2>We are currently experiencing power outages in your area!</h2>
+        <h2>There are currently power outages in your area!</h2>
         {table}
     </body>
     </html>


### PR DESCRIPTION
# Pull Request

## Description

Fixed the wording of the outages email from "We are currently experiencing outages in your area" to "There are currently outages in your area".  

Fixes #206 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

